### PR TITLE
[Config] Modify Configuration to seperate database fields

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,10 @@
-DATABASE_URL=sqlite:///./ratchet.db
+DATABASE_TYPE=sqlite
+DATABASE_NAME=./ratchet.db
+# The following are only needed for PostgreSQL
+# DATABASE_HOST=localhost
+# DATABASE_PORT=5432
+# DATABASE_USER=your_username
+# DATABASE_PASSWORD=your_password
 SLACK_BOT_TOKEN=test
 SLACK_APP_TOKEN=test
 OPENAI_API_KEY=test

--- a/app/config.py
+++ b/app/config.py
@@ -1,11 +1,27 @@
 from pydantic_settings import BaseSettings
+from urllib.parse import quote_plus
 
 
 class Settings(BaseSettings):
-    database_url: str
+    database_type: str
+    database_host: str = ""
+    database_port: str = ""
+    database_name: str
+    database_user: str = ""
+    database_password: str = ""
     slack_bot_token: str
     slack_app_token: str
     openai_api_key: str
 
     class Config:
         env_file = ".env"
+
+    @property
+    def database_url(self):
+        if self.database_type == "sqlite":
+            return f"sqlite:///{self.database_name}"
+        elif self.database_type == "postgresql":
+            password = quote_plus(self.database_password)
+            return f"postgresql://{self.database_user}:{password}@{self.database_host}:{self.database_port}/{self.database_name}"
+        else:
+            raise ValueError(f"Unsupported database type: {self.database_type}")

--- a/app/database.py
+++ b/app/database.py
@@ -12,6 +12,7 @@ engine = create_engine(settings.database_url)
 def init_db():
     """Initialize the database, creating tables if they don't exist."""
     global SessionLocal  # Declare SessionLocal as global
+
     try:
         Base.metadata.create_all(engine)
         print("Tables created successfully.")
@@ -20,7 +21,7 @@ def init_db():
 
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-    return engine, SessionLocal
+    return SessionLocal
 
 
 def get_db():

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,7 @@ app = FastAPI(lifespan=lifespan)
 settings = Settings()
 
 # Initialize the database
-engine, SessionLocal = init_db()
+_ = init_db()
 
 
 @app.get("/")


### PR DESCRIPTION
Instead of maintaining one composite DB URL, lets seperate the fields so that we can fetch secrets from correct secret store.
