### PR TITLE
[Logger] Emit file name and line numbers in logs

### DIFF
--- a/cmd/ratchet/main.go
+++ b/cmd/ratchet/main.go
@@ -47,6 +47,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	wg, ctx := errgroup.WithContext(ctx)
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 


### PR DESCRIPTION
Its easy to debug with file names and line numbers on errors
```
ratchet git:(main) go run ./cmd/ratchet/main.go
2024/11/04 18:15:05 Running version: devel
2024/11/04 18:15:05 error setting up database: unable to apply migrations: no migration found for version 2: read down for version 2 schema/migrations: file does not exist
exit status 1

➜  ratchet git:(main) ✗ go run ./cmd/ratchet/main.go
2024/11/04 18:17:38 main.go:54: Running version: devel
2024/11/04 18:17:38 main.go:73: error setting up database: unable to apply migrations: no migration found for version 2: read down for version 2 schema/migrations: file does not exist
exit status 1
```
