### PR TITLE
[slack] Only persist conversations for enabled channels

### DIFF
--- a/internal/bot.go
+++ b/internal/bot.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
@@ -82,4 +83,12 @@ func (b *Bot) AddMessage(
 	}
 
 	return tx.Commit(ctx)
+}
+
+func (b *Bot) IsChannelEnabled(ctx context.Context, channelID string) (bool, error) {
+	channel, err := b.queries.GetChannelByID(ctx, channelID)
+	if err != nil {
+		return false, fmt.Errorf("failed to get channel: %w", err)
+	}
+	return channel.Enabled, nil
 }

--- a/internal/storage/schema/slack_channels.sql
+++ b/internal/storage/schema/slack_channels.sql
@@ -12,3 +12,6 @@ RETURNING *;
 
 -- name: GetSlackChannels :many
 SELECT * FROM channels;
+
+-- name: GetChannelByID :one
+SELECT * FROM channels WHERE channel_id = $1;

--- a/internal/storage/schema/slack_channels.sql.go
+++ b/internal/storage/schema/slack_channels.sql.go
@@ -23,6 +23,17 @@ func (q *Queries) DisableSlackChannel(ctx context.Context, channelID string) (Ch
 	return i, err
 }
 
+const getChannelByID = `-- name: GetChannelByID :one
+SELECT channel_id, enabled, created_at FROM channels WHERE channel_id = $1
+`
+
+func (q *Queries) GetChannelByID(ctx context.Context, channelID string) (Channel, error) {
+	row := q.db.QueryRow(ctx, getChannelByID, channelID)
+	var i Channel
+	err := row.Scan(&i.ChannelID, &i.Enabled, &i.CreatedAt)
+	return i, err
+}
+
 const getSlackChannels = `-- name: GetSlackChannels :many
 SELECT channel_id, enabled, created_at FROM channels
 `


### PR DESCRIPTION
Currently, we are processing all slack events, i.e. whenever a new channel is created or a new message sent in any channel in the workspace, we end up persisting the messages and adding the channels to our enabled channels, this will overwhelm the application in real world. So, process events for channels only where our application enabled/onboarded.
