### PR TITLE
[Ingestion] Add historical messages

### DIFF
--- a/internal/background/classifier_worker/worker.go
+++ b/internal/background/classifier_worker/worker.go
@@ -25,7 +25,7 @@ type Config struct {
 
 	// In case it is possible to deterministically classify an incident (the alert bot always uses
 	// the same message format), we can use this to classify the incident without using the OpenAI API.
-	IncidentBinary string `split_words:"true" required:"true"`
+	IncidentBinary string `split_words:"true" required:"false"`
 }
 
 type ClassifierWorker struct {
@@ -130,6 +130,8 @@ func (w *ClassifierWorker) Work(ctx context.Context, job *river.Job[background.C
 		if err := w.processIncidentAction(ctx, msg, action); err != nil {
 			return fmt.Errorf("failed to process incident action: %w", err)
 		}
+	} else {
+		log.Printf("no incident binary found, skipping classification")
 	}
 
 	// TODO: Use OpenAI API to classify incidents, bot updates and human interactions.

--- a/internal/background/client.go
+++ b/internal/background/client.go
@@ -1,6 +1,8 @@
 package background
 
 import (
+	"time"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
@@ -14,6 +16,20 @@ type ClassifierArgs struct {
 
 func (c ClassifierArgs) Kind() string {
 	return "classifier"
+}
+
+const (
+	DefaultHistoricalLookbackPeriod = 14 * 24 * time.Hour // 2 weeks
+)
+
+type MessagesIngestionWorkerArgs struct {
+	ChannelID string    `json:"channel_id"`
+	StartTime time.Time `json:"start_time"`
+	EndTime   time.Time `json:"end_time"`
+}
+
+func (m MessagesIngestionWorkerArgs) Kind() string {
+	return "ingest_historical_messages"
 }
 
 func New(db *pgxpool.Pool, workers *river.Workers) (*river.Client[pgx.Tx], error) {

--- a/internal/background/ingestion_worker/worker.go
+++ b/internal/background/ingestion_worker/worker.go
@@ -1,0 +1,69 @@
+package ingestion_worker
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/dynoinc/ratchet/internal"
+	"github.com/dynoinc/ratchet/internal/background"
+	"github.com/dynoinc/ratchet/internal/storage/schema/dto"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/riverqueue/river"
+	"github.com/slack-go/slack"
+)
+
+type MessagesIngestionWorker struct {
+	river.WorkerDefaults[background.MessagesIngestionWorkerArgs]
+	bot         *internal.Bot
+	slackClient *slack.Client
+}
+
+func New(bot *internal.Bot, slackClient *slack.Client) (*MessagesIngestionWorker, error) {
+	return &MessagesIngestionWorker{bot: bot, slackClient: slackClient}, nil
+}
+
+func (w *MessagesIngestionWorker) Work(ctx context.Context, j *river.Job[background.MessagesIngestionWorkerArgs]) error {
+	log.Printf("ingesting messages for channel %s", j.Args.ChannelID)
+	params := slack.GetConversationHistoryParameters{
+		ChannelID: j.Args.ChannelID,
+		Limit:     100,
+		Oldest:    j.Args.StartTime.Format(time.RFC3339),
+		Latest:    j.Args.EndTime.Format(time.RFC3339),
+	}
+
+	for {
+		messages, err := w.slackClient.GetConversationHistory(&params)
+		if err != nil {
+			log.Printf("error getting conversation history: %v", err)
+			return err
+		}
+		log.Printf("got %d messages", len(messages.Messages))
+
+		for _, msg := range messages.Messages {
+			// Attempt to add each message, ignoring duplicate errors
+			err := w.bot.AddMessage(ctx, j.Args.ChannelID, msg.Timestamp, dto.MessageAttrs{Message: msg})
+			if err != nil && !isDuplicateError(err) {
+				return err
+			}
+		}
+
+		if messages.HasMore {
+			params.Cursor = messages.Messages[len(messages.Messages)-1].Timestamp
+		} else {
+			break
+		}
+	}
+	return nil
+}
+
+// helper function to check for duplicate message errors
+func isDuplicateError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgerrcode.UniqueViolation
+	}
+	return false
+}

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -97,3 +97,7 @@ func (b *Integration) handleEventAPI(ctx context.Context, event slackevents.Even
 		}
 	}
 }
+
+func (b *Integration) SlackClient() *slack.Client {
+	return &b.client.Client
+}

--- a/internal/storage/schema/dto/structs.go
+++ b/internal/storage/schema/dto/structs.go
@@ -1,9 +1,13 @@
 package dto
 
-import "github.com/slack-go/slack/slackevents"
+import (
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+)
 
 type MessageAttrs struct {
 	Upstream slackevents.MessageEvent `json:"upstream"`
+	Message  slack.Message            `json:"message"`
 }
 
 type IncidentAttrs struct {


### PR DESCRIPTION
Add ingestion background worker to fetch and ingest messages if not exist for upto last two weeks (configured value, for now hardcoded).
This enqueues whenever a new channel is inserted or during startup to see if we need to backfill.
