### PR TITLE
[Channel Info] Fix populating channel attributes

### DIFF
--- a/internal/storage/schema/channels.sql
+++ b/internal/storage/schema/channels.sql
@@ -6,7 +6,11 @@ INSERT INTO channels (
     $1, $2
 )
 ON CONFLICT (channel_id) DO UPDATE
-SET attrs = COALESCE(EXCLUDED.attrs, channels.attrs)
+SET attrs = CASE
+    WHEN EXCLUDED.attrs IS NULL OR EXCLUDED.attrs = '{}'::jsonb
+    THEN channels.attrs
+    ELSE EXCLUDED.attrs
+END
 RETURNING *;
 
 -- name: GetChannel :one

--- a/internal/storage/schema/channels.sql.go
+++ b/internal/storage/schema/channels.sql.go
@@ -19,7 +19,11 @@ INSERT INTO channels (
     $1, $2
 )
 ON CONFLICT (channel_id) DO UPDATE
-SET attrs = COALESCE(EXCLUDED.attrs, channels.attrs)
+SET attrs = CASE
+    WHEN EXCLUDED.attrs IS NULL OR EXCLUDED.attrs = '{}'::jsonb
+    THEN channels.attrs
+    ELSE EXCLUDED.attrs
+END
 RETURNING channel_id, attrs, created_at, slack_ts_watermark
 `
 


### PR DESCRIPTION
Currently, once the channel Info job is scheduled we don't insert a duplicate one and also there is a bug which unsets the attributes. Fixed both of these and also added this to populate channel info on add messages as well.