### PR TITLE
Move Slack integration and LLM client to interfaces for mocking in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ bin/
 
 # Editor backup files
 *.orig
+
+# IntelliJ IDEA
+.idea

--- a/internal/background/backfill_thread_worker/worker.go
+++ b/internal/background/backfill_thread_worker/worker.go
@@ -17,10 +17,10 @@ type backfillThreadWorker struct {
 	river.WorkerDefaults[background.BackfillThreadWorkerArgs]
 
 	bot              *internal.Bot
-	slackIntegration *slack_integration.Integration
+	slackIntegration slack_integration.Integration
 }
 
-func New(bot *internal.Bot, slackIntegration *slack_integration.Integration) *backfillThreadWorker {
+func New(bot *internal.Bot, slackIntegration slack_integration.Integration) *backfillThreadWorker {
 	return &backfillThreadWorker{
 		bot:              bot,
 		slackIntegration: slackIntegration,

--- a/internal/background/channel_onboard_worker/worker.go
+++ b/internal/background/channel_onboard_worker/worker.go
@@ -20,10 +20,10 @@ type ChannelOnboardWorker struct {
 	river.WorkerDefaults[background.ChannelOnboardWorkerArgs]
 
 	bot              *internal.Bot
-	slackIntegration *slack_integration.Integration
+	slackIntegration slack_integration.Integration
 }
 
-func New(bot *internal.Bot, slackIntegration *slack_integration.Integration) *ChannelOnboardWorker {
+func New(bot *internal.Bot, slackIntegration slack_integration.Integration) *ChannelOnboardWorker {
 	return &ChannelOnboardWorker{
 		bot:              bot,
 		slackIntegration: slackIntegration,

--- a/internal/background/classifier_worker/worker.go
+++ b/internal/background/classifier_worker/worker.go
@@ -30,10 +30,10 @@ type classifierWorker struct {
 
 	incidentBinary string
 	bot            *internal.Bot
-	llmClient      *llm.Client
+	llmClient      llm.Client
 }
 
-func New(c Config, bot *internal.Bot, llmClient *llm.Client) (river.Worker[background.ClassifierArgs], error) {
+func New(c Config, bot *internal.Bot, llmClient llm.Client) (river.Worker[background.ClassifierArgs], error) {
 	if _, err := exec.LookPath(c.IncidentClassificationBinary); err != nil {
 		return nil, fmt.Errorf("looking up incident classification binary: %w", err)
 	}

--- a/internal/modules/commands/cmds.go
+++ b/internal/modules/commands/cmds.go
@@ -31,8 +31,8 @@ var (
 
 type commands struct {
 	bot              *internal.Bot
-	slackIntegration *slack_integration.Integration
-	llmClient        *llm.Client
+	slackIntegration slack_integration.Integration
+	llmClient        llm.Client
 
 	mu         sync.Mutex
 	embeddings map[cmd][]float64
@@ -40,8 +40,8 @@ type commands struct {
 
 func New(
 	bot *internal.Bot,
-	slackIntegration *slack_integration.Integration,
-	llmClient *llm.Client,
+	slackIntegration slack_integration.Integration,
+	llmClient llm.Client,
 ) *commands {
 	return &commands{
 		bot:              bot,
@@ -130,7 +130,7 @@ func (c *commands) findCommand(ctx context.Context, msg dto.SlackMessage) (cmd, 
 }
 
 func (c *commands) Handle(ctx context.Context, channelID string, slackTS string, msg dto.MessageAttrs) error {
-	botID := c.slackIntegration.BotUserID
+	botID := c.slackIntegration.BotUserID()
 	if !strings.HasPrefix(msg.Message.Text, fmt.Sprintf("<@%s> ", botID)) {
 		return nil
 	}

--- a/internal/modules/recent_activity/compute.go
+++ b/internal/modules/recent_activity/compute.go
@@ -25,7 +25,7 @@ type Activity struct {
 func Get(
 	ctx context.Context,
 	qtx *schema.Queries,
-	llmClient *llm.Client,
+	llmClient llm.Client,
 	serviceName, alertName string,
 	interval time.Duration,
 	botID string,

--- a/internal/modules/report/post.go
+++ b/internal/modules/report/post.go
@@ -19,8 +19,8 @@ import (
 func Post(
 	ctx context.Context,
 	qtx *schema.Queries,
-	llmClient *llm.Client,
-	slackIntegration *slack_integration.Integration,
+	llmClient llm.Client,
+	slackIntegration slack_integration.Integration,
 	channelID string,
 ) error {
 	messages, err := qtx.GetMessagesWithinTS(ctx, schema.GetMessagesWithinTSParams{

--- a/internal/modules/runbook/get.go
+++ b/internal/modules/runbook/get.go
@@ -16,7 +16,7 @@ import (
 func Get(
 	ctx context.Context,
 	qtx *schema.Queries,
-	llmClient *llm.Client,
+	llmClient llm.Client,
 	serviceName, alertName string,
 	botID string,
 ) ([]slack.Block, error) {

--- a/internal/modules/runbook/handler.go
+++ b/internal/modules/runbook/handler.go
@@ -12,11 +12,11 @@ import (
 
 type Handler struct {
 	bot              *internal.Bot
-	slackIntegration *slack_integration.Integration
-	llmClient        *llm.Client
+	slackIntegration slack_integration.Integration
+	llmClient        llm.Client
 }
 
-func New(bot *internal.Bot, slackIntegration *slack_integration.Integration, llmClient *llm.Client) *Handler {
+func New(bot *internal.Bot, slackIntegration slack_integration.Integration, llmClient llm.Client) *Handler {
 	return &Handler{
 		bot:              bot,
 		slackIntegration: slackIntegration,
@@ -34,7 +34,7 @@ func (h *Handler) Handle(ctx context.Context, channelID string, slackTS string, 
 	}
 
 	qtx := schema.New(h.bot.DB)
-	blocks, err := Get(ctx, qtx, h.llmClient, msg.IncidentAction.Service, msg.IncidentAction.Alert, h.slackIntegration.BotUserID)
+	blocks, err := Get(ctx, qtx, h.llmClient, msg.IncidentAction.Service, msg.IncidentAction.Alert, h.slackIntegration.BotUserID())
 	if err != nil {
 		return err
 	}

--- a/internal/modules/runbook/post.go
+++ b/internal/modules/runbook/post.go
@@ -7,6 +7,6 @@ import (
 	"github.com/slack-go/slack"
 )
 
-func Post(ctx context.Context, slackIntegration *slack_integration.Integration, channelID, slackTS string, blocks ...slack.Block) error {
+func Post(ctx context.Context, slackIntegration slack_integration.Integration, channelID, slackTS string, blocks ...slack.Block) error {
 	return slackIntegration.PostThreadReply(ctx, channelID, slackTS, blocks...)
 }

--- a/internal/modules/runbook/update.go
+++ b/internal/modules/runbook/update.go
@@ -14,7 +14,7 @@ import (
 func Update(
 	ctx context.Context,
 	qtx *schema.Queries,
-	llmClient *llm.Client,
+	llmClient llm.Client,
 	serviceName, alertName string,
 	forceRecreate bool,
 ) (string, error) {

--- a/internal/web/http.go
+++ b/internal/web/http.go
@@ -58,16 +58,16 @@ func handleJSON(handler func(*http.Request) (any, error)) http.HandlerFunc {
 type httpHandlers struct {
 	db               *pgxpool.Pool
 	riverClient      *river.Client[pgx.Tx]
-	slackIntegration *slack_integration.Integration
-	llmClient        *llm.Client
+	slackIntegration slack_integration.Integration
+	llmClient        llm.Client
 }
 
 func New(
 	ctx context.Context,
 	db *pgxpool.Pool,
 	riverClient *river.Client[pgx.Tx],
-	slackIntegration *slack_integration.Integration,
-	llmClient *llm.Client,
+	slackIntegration slack_integration.Integration,
+	llmClient llm.Client,
 ) (http.Handler, error) {
 	handlers := &httpHandlers{
 		db:               db,
@@ -349,7 +349,7 @@ func (h *httpHandlers) getRecentActivity(r *http.Request) (any, error) {
 		serviceName,
 		alertName,
 		intervalDuration,
-		h.slackIntegration.BotUserID,
+		h.slackIntegration.BotUserID(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
Making Slack Integration and LLM Client interfaces to make it easier to mock them in unit tests
