### PR TITLE
Run channel monitor test LLM completions in parallel

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Ratchet",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "cmd/ratchet/main.go",
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/internal/modules/channel_monitor/http.go
+++ b/internal/modules/channel_monitor/http.go
@@ -208,6 +208,7 @@ func renderPage(w http.ResponseWriter, prefix string) {
 <html>
 <head>
 	<title>Test Channel Monitor</title>
+	<script src="https://unpkg.com/htmx.org@2.0.4"></script>
 	<style>
 		body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; max-width: 800px; margin: 40px auto; padding: 0 20px; }
 		textarea { width: 100%%; height: 300px; margin: 10px 0; font-family: monospace; }
@@ -269,26 +270,27 @@ func renderTestReport(results []*TestChannelMonitorReportData) string {
 	reportHTML := `<!DOCTYPE html>
 <html>
 <head>
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; max-width: 800px; margin: 40px auto; padding: 0 20px; }
-h1 { color: #2c3e50; border-bottom: 2px solid #eee; padding-bottom: 10px; }
-h3 { color: #34495e; margin-top: 30px; }
-details { background: #f8f9fa; padding: 10px; border-radius: 4px; margin: 10px 0; }
-summary { cursor: pointer; color: #2980b9; }
-pre { background: #f8f9fa; padding: 15px; border-radius: 4px; overflow-x: auto; }
-.error { color: #e74c3c; }
-hr { border: none; border-top: 1px solid #eee; margin: 30px 0; }
-.download-btn { 
-    background: #2980b9; 
-    color: white; 
-    padding: 10px 20px; 
-    border: none; 
-    border-radius: 4px; 
-    cursor: pointer; 
-    margin: 20px 0;
-    text-decoration: none;
-    display: inline-block;
-}
-.download-btn:hover { background: #2471a3; }
+<style>
+	body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; max-width: 800px; margin: 40px auto; padding: 0 20px; }
+	h1 { color: #2c3e50; border-bottom: 2px solid #eee; padding-bottom: 10px; }
+	h3 { color: #34495e; margin-top: 30px; }
+	details { background: #f8f9fa; padding: 10px; border-radius: 4px; margin: 10px 0; }
+	summary { cursor: pointer; color: #2980b9; }
+	pre { background: #f8f9fa; padding: 15px; border-radius: 4px; overflow-x: auto; }
+	.error { color: #e74c3c; }
+	hr { border: none; border-top: 1px solid #eee; margin: 30px 0; }
+	.download-btn { 
+		background: #2980b9; 
+		color: white; 
+		padding: 10px 20px; 
+		border: none; 
+		border-radius: 4px; 
+		cursor: pointer; 
+		margin: 20px 0;
+		text-decoration: none;
+		display: inline-block;
+	}
+	.download-btn:hover { background: #2471a3; }
 </style>
 </head>
 <body>

--- a/internal/modules/channel_monitor/http.go
+++ b/internal/modules/channel_monitor/http.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 
 	"gopkg.in/yaml.v3"
@@ -81,67 +82,7 @@ func HTTPHandler(
 			w.Write([]byte(report))
 		}
 		if r.Method == "GET" {
-			w.Header().Set("Content-Type", "text/html")
-			w.Write([]byte(`<!DOCTYPE html>
-<html>
-<head>
-	<title>Test Channel Monitor</title>
-	<script src="https://unpkg.com/htmx.org@2.0.4"></script>
-	<style>
-		body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; max-width: 800px; margin: 40px auto; padding: 0 20px; }
-		textarea { width: 100%; height: 300px; margin: 10px 0; font-family: monospace; }
-		.spinner { display: none; }
-		.htmx-request .spinner { display: inline; }
-		.htmx-request .submit { display: none; }
-		h1 { color: #2c3e50; border-bottom: 2px solid #eee; padding-bottom: 10px; }
-		h3 { color: #34495e; margin-top: 30px; }
-		details { background: #f8f9fa; padding: 10px; border-radius: 4px; margin: 10px 0; }
-		summary { cursor: pointer; color: #2980b9; }
-		pre { background: #f8f9fa; padding: 15px; border-radius: 4px; overflow-x: auto; }
-		.error { color: #e74c3c; }
-		hr { border: none; border-top: 1px solid #eee; margin: 30px 0; }
-		.download-btn { 
-			background: #2980b9; 
-			color: white; 
-			padding: 10px 20px; 
-			border: none; 
-			border-radius: 4px; 
-			cursor: pointer; 
-			margin: 20px 0;
-			text-decoration: none;
-			display: inline-block;
-		}
-		.download-btn:hover { background: #2471a3; }
-	</style>
-</head>
-<body>
-	<div id="report-input">
-		<h1>Test Channel Monitor</h1>
-		<form hx-post="` + prefix + `/test" hx-target="#result" hx-swap="innerHTML">
-			<div>
-				<label for="config">Config YAML:</label><br>
-				<textarea name="config_yaml" id="config"></textarea>
-			</div>
-			<div>
-				<label for="count">Recent Messages To Fetch From Slack Channel:</label><br>
-				<input type="number" name="message_count" id="count" value="3">
-			</div>
-			<div>
-				<label for="messages">Additional Messages to Test (seperate with --- line):</label><br>
-				<textarea name="test_messages" id="messages"></textarea>
-			</div>
-			<button type="submit" class="submit">Test</button>
-			<span class="spinner">Testing...</span>
-		</form>
-	</div>
-	<div id="result"></div>
-	<script>
-		document.body.addEventListener('htmx:responseError', function(evt) {
-			evt.detail.target.innerHTML = '<div class="error">Error: ' + evt.detail.error + '<br>Response: ' + evt.detail.xhr.responseText + '</div>';
-		});
-	</script>
-</body>
-</html>`))
+			renderPage(w, prefix)
 		}
 	})
 	return mux
@@ -160,109 +101,50 @@ func testChannelMonitorPrompt(ctx context.Context,
 	if err != nil {
 		return "", err
 	}
-	results := []*TestChannelMonitorReportData{}
-	for _, msg := range history {
-		data := PromptData{Message: msg}
-		var prompt bytes.Buffer
-		err := entry.PromptTemplate.Execute(&prompt, data)
-		if err != nil {
-			return "", fmt.Errorf("executing prompt template: %w", err)
-		}
-		validOutput, invalidOutput, err := llmClient.RunJSONModePrompt(ctx, prompt.String(), entry.ResultSchema)
-		reportData := &TestChannelMonitorReportData{
-			Message:         msg,
-			Prompt:          prompt.String(),
-			ValidatedOutput: validOutput,
-			InvalidOutput:   invalidOutput,
-		}
-		if err != nil {
-			reportData.Error = err.Error()
-		}
-		results = append(results, reportData)
-	}
-	reportHTML := `<!DOCTYPE html>
-<html>
-<head>
-<style>
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; max-width: 800px; margin: 40px auto; padding: 0 20px; }
-h1 { color: #2c3e50; border-bottom: 2px solid #eee; padding-bottom: 10px; }
-h3 { color: #34495e; margin-top: 30px; }
-details { background: #f8f9fa; padding: 10px; border-radius: 4px; margin: 10px 0; }
-summary { cursor: pointer; color: #2980b9; }
-pre { background: #f8f9fa; padding: 15px; border-radius: 4px; overflow-x: auto; }
-.error { color: #e74c3c; }
-hr { border: none; border-top: 1px solid #eee; margin: 30px 0; }
-.download-btn { 
-    background: #2980b9; 
-    color: white; 
-    padding: 10px 20px; 
-    border: none; 
-    border-radius: 4px; 
-    cursor: pointer; 
-    margin: 20px 0;
-    text-decoration: none;
-    display: inline-block;
+	results := getTestResults(ctx, history, entry, llmClient) // Wait for all goroutines to complete
+	return renderTestReport(results), nil
 }
-.download-btn:hover { background: #2471a3; }
-</style>
-</head>
-<body>
-<h1>Test Channel Monitor Report</h1>
-<button id="download-btn" onclick="downloadReport()" class="download-btn">Download Report</button>
-<script>
-function downloadReport() {
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const filename = 'channel-report-' + timestamp + '.html';
-	// Clone the document and remove the report input content and download button
-    const clonedDoc = document.documentElement.cloneNode(true);
-    const reportInput = clonedDoc.querySelector('#report-input');
-    reportInput.remove();
-	const downloadBtn = clonedDoc.querySelector('#download-btn');
-	downloadBtn.remove();
-    const htmlContent = clonedDoc.outerHTML;
-    
-    const blob = new Blob([htmlContent], { type: 'text/html' });
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    window.URL.revokeObjectURL(url);
-    document.body.removeChild(a);
-}
-</script>
-`
-	for _, data := range results {
-		reportHTML += fmt.Sprintf(`
-<h3>Message</h3>
-<p>%s</p>
-<details>
-<summary>Prompt</summary>
-<pre>%s</pre>
-</details>`, html.EscapeString(data.Message.Text), html.EscapeString(data.Prompt))
 
-		if data.ValidatedOutput != "" {
-			reportHTML += fmt.Sprintf(`
-<h3>Output</h3>
-<pre>%s</pre>`, html.EscapeString(data.ValidatedOutput))
-		}
+func getTestResults(ctx context.Context, history []dto.SlackMessage, entry *Entry, llmClient llm.Client) []*TestChannelMonitorReportData {
+	results := make([]*TestChannelMonitorReportData, len(history))
+	var wg sync.WaitGroup
+	resultsMutex := &sync.Mutex{}
+	semaphore := make(chan struct{}, 5) // Limit concurrency to 5 parallel requests
 
-		if data.InvalidOutput != "" {
-			reportHTML += fmt.Sprintf(`
-<h3>Invalid Output</h3>
-<pre style="background: #ffebee; border-radius: 4px; padding: 10px; margin: 5px 0; color: #d32f2f;">%s</pre>`, html.EscapeString(data.InvalidOutput))
-		}
+	for i, msg := range history {
+		wg.Add(1)
+		semaphore <- struct{}{} // Acquire semaphore
+		go func(idx int, message dto.SlackMessage) {
+			defer wg.Done()
+			defer func() { <-semaphore }() // Release semaphore
 
-		if data.Error != "" {
-			reportHTML += fmt.Sprintf(`
-<pre style="background: #ffebee; border-radius: 4px; padding: 10px; margin: 5px 0; color: #d32f2f;">Error: %s</pre>`, html.EscapeString(data.Error))
-		}
+			data := PromptData{Message: message}
+			var prompt bytes.Buffer
+			err := entry.PromptTemplate.Execute(&prompt, data)
 
-		reportHTML += "<hr>"
+			reportData := &TestChannelMonitorReportData{
+				Message: message,
+				Prompt:  prompt.String(),
+			}
+
+			if err != nil {
+				reportData.Error = fmt.Sprintf("executing prompt template: %v", err)
+			} else {
+				validOutput, invalidOutput, err := llmClient.RunJSONModePrompt(ctx, prompt.String(), entry.ResultSchema)
+				reportData.ValidatedOutput = validOutput
+				reportData.InvalidOutput = invalidOutput
+				if err != nil {
+					reportData.Error = err.Error()
+				}
+			}
+
+			resultsMutex.Lock()
+			results[idx] = reportData
+			resultsMutex.Unlock()
+		}(i, msg)
 	}
-	reportHTML += "</body></html>"
-	return reportHTML, nil
+	wg.Wait()
+	return results
 }
 
 func getEntryForTest(req TestChannelMonitorRequest) (*Entry, error) {
@@ -318,4 +200,152 @@ func getMessagesForTest(ctx context.Context, slackIntegration slack_integration.
 		}
 	}
 	return history, nil
+}
+
+func renderPage(w http.ResponseWriter, prefix string) {
+	w.Header().Set("Content-Type", "text/html")
+	w.Write(fmt.Appendf(nil, `<!DOCTYPE html>
+<html>
+<head>
+	<title>Test Channel Monitor</title>
+	<style>
+		body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; max-width: 800px; margin: 40px auto; padding: 0 20px; }
+		textarea { width: 100%%; height: 300px; margin: 10px 0; font-family: monospace; }
+		.spinner { display: none; }
+		.htmx-request .spinner { display: inline; }
+		.htmx-request .submit { display: none; }
+		h1 { color: #2c3e50; border-bottom: 2px solid #eee; padding-bottom: 10px; }
+		h3 { color: #34495e; margin-top: 30px; }
+		details { background: #f8f9fa; padding: 10px; border-radius: 4px; margin: 10px 0; }
+		summary { cursor: pointer; color: #2980b9; }
+		pre { background: #f8f9fa; padding: 15px; border-radius: 4px; overflow-x: auto; }
+		.error { color: #e74c3c; }
+		hr { border: none; border-top: 1px solid #eee; margin: 30px 0; }
+		.download-btn { 
+			background: #2980b9; 
+			color: white; 
+			padding: 10px 20px; 
+			border: none; 
+			border-radius: 4px; 
+			cursor: pointer; 
+			margin: 20px 0;
+			text-decoration: none;
+			display: inline-block;
+		}
+		.download-btn:hover { background: #2471a3; }
+	</style>
+</head>
+<body>
+	<div id="report-input">
+		<h1>Test Channel Monitor</h1>
+		<form hx-post="%s/test" hx-target="#result" hx-swap="innerHTML">
+			<div>
+				<label for="config">Config YAML:</label><br>
+				<textarea name="config_yaml" id="config"></textarea>
+			</div>
+			<div>
+				<label for="count">Recent Messages To Fetch From Slack Channel:</label><br>
+				<input type="number" name="message_count" id="count" value="3">
+			</div>
+			<div>
+				<label for="messages">Additional Messages to Test (seperate with --- line):</label><br>
+				<textarea name="test_messages" id="messages"></textarea>
+			</div>
+			<button type="submit" class="submit">Test</button>
+			<span class="spinner">Testing...</span>
+		</form>
+	</div>
+	<div id="result"></div>
+	<script>
+		document.body.addEventListener('htmx:responseError', function(evt) {
+			evt.detail.target.innerHTML = '<div class="error">Error: ' + evt.detail.error + '<br>Response: ' + evt.detail.xhr.responseText + '</div>';
+		});
+	</script>
+</body>
+</html>`, prefix))
+}
+
+func renderTestReport(results []*TestChannelMonitorReportData) string {
+	reportHTML := `<!DOCTYPE html>
+<html>
+<head>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; max-width: 800px; margin: 40px auto; padding: 0 20px; }
+h1 { color: #2c3e50; border-bottom: 2px solid #eee; padding-bottom: 10px; }
+h3 { color: #34495e; margin-top: 30px; }
+details { background: #f8f9fa; padding: 10px; border-radius: 4px; margin: 10px 0; }
+summary { cursor: pointer; color: #2980b9; }
+pre { background: #f8f9fa; padding: 15px; border-radius: 4px; overflow-x: auto; }
+.error { color: #e74c3c; }
+hr { border: none; border-top: 1px solid #eee; margin: 30px 0; }
+.download-btn { 
+    background: #2980b9; 
+    color: white; 
+    padding: 10px 20px; 
+    border: none; 
+    border-radius: 4px; 
+    cursor: pointer; 
+    margin: 20px 0;
+    text-decoration: none;
+    display: inline-block;
+}
+.download-btn:hover { background: #2471a3; }
+</style>
+</head>
+<body>
+<h1>Test Channel Monitor Report</h1>
+<button id="download-btn" onclick="downloadReport()" class="download-btn">Download Report</button>
+<script>
+function downloadReport() {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = 'channel-report-' + timestamp + '.html';
+	// Clone the document and remove the report input content and download button
+    const clonedDoc = document.documentElement.cloneNode(true);
+    const reportInput = clonedDoc.querySelector('#report-input');
+    reportInput.remove();
+	const downloadBtn = clonedDoc.querySelector('#download-btn');
+	downloadBtn.remove();
+    const htmlContent = clonedDoc.outerHTML;
+    
+    const blob = new Blob([htmlContent], { type: 'text/html' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    window.URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+}
+</script>`
+
+	for _, data := range results {
+		reportHTML += fmt.Sprintf(`
+<h3>Message</h3>
+<p>%s</p>
+<details>
+<summary>Prompt</summary>
+<pre>%s</pre>
+</details>`, html.EscapeString(data.Message.Text), html.EscapeString(data.Prompt))
+
+		if data.ValidatedOutput != "" {
+			reportHTML += fmt.Sprintf(`
+<h3>Output</h3>
+<pre>%s</pre>`, html.EscapeString(data.ValidatedOutput))
+		}
+
+		if data.InvalidOutput != "" {
+			reportHTML += fmt.Sprintf(`
+<h3>Invalid Output</h3>
+<pre style="background: #ffebee; border-radius: 4px; padding: 10px; margin: 5px 0; color: #d32f2f;">%s</pre>`, html.EscapeString(data.InvalidOutput))
+		}
+
+		if data.Error != "" {
+			reportHTML += fmt.Sprintf(`
+<pre style="background: #ffebee; border-radius: 4px; padding: 10px; margin: 5px 0; color: #d32f2f;">Error: %s</pre>`, html.EscapeString(data.Error))
+		}
+
+		reportHTML += "<hr>"
+	}
+	reportHTML += "</body></html>"
+	return reportHTML
 }

--- a/internal/modules/channel_monitor/http.go
+++ b/internal/modules/channel_monitor/http.go
@@ -204,7 +204,7 @@ func getMessagesForTest(ctx context.Context, slackIntegration slack_integration.
 
 func renderPage(w http.ResponseWriter, prefix string) {
 	w.Header().Set("Content-Type", "text/html")
-	w.Write(fmt.Appendf(nil, `<!DOCTYPE html>
+	w.Write([]byte(fmt.Sprintf(`<!DOCTYPE html>
 <html>
 <head>
 	<title>Test Channel Monitor</title>
@@ -263,7 +263,7 @@ func renderPage(w http.ResponseWriter, prefix string) {
 		});
 	</script>
 </body>
-</html>`, prefix))
+</html>`, prefix)))
 }
 
 func renderTestReport(results []*TestChannelMonitorReportData) string {

--- a/internal/modules/channel_monitor/http_test.go
+++ b/internal/modules/channel_monitor/http_test.go
@@ -1,0 +1,144 @@
+package channel_monitor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/dynoinc/ratchet/internal/modules/channel_monitor/mocks"
+	"github.com/dynoinc/ratchet/internal/storage/schema/dto"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetTestResults_MaintainsOrder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create test messages with identifiable order
+	messages := []dto.SlackMessage{
+		{Text: "message 1"},
+		{Text: "message 2"},
+		{Text: "message 3"},
+		{Text: "message 4"},
+		{Text: "message 5"},
+	}
+
+	// Create entry with simple template
+	entry := &Entry{
+		PromptTemplate: template.Must(template.New("test").Parse("prompt for: {{.Message.Text}}")),
+	}
+
+	// Create mock LLM client
+	mockLLM := mocks.NewMockClient(ctrl)
+
+	// Set up expectations for each message
+	for i, msg := range messages {
+		expectedPrompt := fmt.Sprintf("prompt for: %s", msg.Text)
+		expectedOutput := fmt.Sprintf("valid output for: %s", msg.Text)
+		mockLLM.EXPECT().
+			RunJSONModePrompt(gomock.Any(), expectedPrompt, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, prompt string, schema interface{}) (string, string, error) {
+				// Add small random delay to test concurrent processing
+				time.Sleep(time.Duration(10+i*5) * time.Millisecond)
+				return expectedOutput, "", nil
+			})
+	}
+
+	// Get results
+	results := getTestResults(context.Background(), messages, entry, mockLLM)
+
+	// Verify results length
+	assert.Equal(t, len(messages), len(results), "should have same number of results as messages")
+
+	// Verify order is maintained
+	for i, result := range results {
+		expectedMessage := messages[i]
+		assert.Equal(t, expectedMessage.Text, result.Message.Text, "message at index %d should match", i)
+
+		expectedPrompt := fmt.Sprintf("prompt for: %s", expectedMessage.Text)
+		assert.Equal(t, expectedPrompt, result.Prompt, "prompt at index %d should match", i)
+
+		expectedOutput := fmt.Sprintf("valid output for: %s", expectedMessage.Text)
+		assert.Equal(t, expectedOutput, result.ValidatedOutput, "output at index %d should match", i)
+	}
+}
+
+func TestGetTestResults_HandlesErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create test messages
+	messages := []dto.SlackMessage{
+		{Text: "message 1"},
+	}
+
+	// Create entry with invalid template to trigger error
+	entry := &Entry{
+		PromptTemplate: template.Must(template.New("test").Parse("{{.InvalidField}}")),
+	}
+
+	// Create mock LLM client
+	mockLLM := mocks.NewMockClient(ctrl)
+
+	// Get results
+	results := getTestResults(context.Background(), messages, entry, mockLLM)
+
+	// Verify error is captured
+	assert.Equal(t, 1, len(results), "should have one result")
+	assert.Contains(t, results[0].Error, "executing prompt template", "should contain template error")
+}
+
+func TestGetTestResults_ConcurrencyLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create many test messages
+	messages := make([]dto.SlackMessage, 20)
+	for i := range messages {
+		messages[i] = dto.SlackMessage{Text: fmt.Sprintf("message %d", i+1)}
+	}
+
+	// Create entry with simple template
+	entry := &Entry{
+		PromptTemplate: template.Must(template.New("test").Parse("prompt for: {{.Message.Text}}")),
+	}
+
+	// Create mock LLM client
+	mockLLM := mocks.NewMockClient(ctrl)
+
+	// Set up expectations for each message with a delay
+	for _, msg := range messages {
+		expectedPrompt := fmt.Sprintf("prompt for: %s", msg.Text)
+		expectedOutput := fmt.Sprintf("valid output for: %s", msg.Text)
+		mockLLM.EXPECT().
+			RunJSONModePrompt(gomock.Any(), expectedPrompt, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, prompt string, schema interface{}) (string, string, error) {
+				time.Sleep(100 * time.Millisecond)
+				return expectedOutput, "", nil
+			})
+	}
+
+	start := time.Now()
+
+	// Get results
+	results := getTestResults(context.Background(), messages, entry, mockLLM)
+
+	duration := time.Since(start)
+
+	// With 20 messages and 100ms delay per message:
+	// - If running serially: would take ~2000ms
+	// - If running fully parallel: would take ~100ms
+	// - With 5 concurrent limit: should take ~400ms (4 batches of 5 messages)
+	// Add some buffer for processing overhead
+	assert.Greater(t, duration, 400*time.Millisecond, "should not be fully parallel")
+	assert.Less(t, duration, 2000*time.Millisecond, "should not be fully serial")
+
+	// Verify all results are present and in order
+	assert.Equal(t, len(messages), len(results), "should have all results")
+	for i, result := range results {
+		assert.Equal(t, fmt.Sprintf("message %d", i+1), result.Message.Text, "messages should be in order")
+	}
+}


### PR DESCRIPTION
Run 5 test messages in parallel to increase the performance of the channel test endpoint without overloading the API.