### PR TITLE
Fix typo in channel monitor HTML

### DIFF
--- a/internal/modules/channel_monitor/http.go
+++ b/internal/modules/channel_monitor/http.go
@@ -249,7 +249,7 @@ func renderPage(w http.ResponseWriter, prefix string) {
 				<input type="number" name="message_count" id="count" value="3">
 			</div>
 			<div>
-				<label for="messages">Additional Messages to Test (seperate with --- line):</label><br>
+				<label for="messages">Additional Messages to Test (separate with --- line):</label><br>
 				<textarea name="test_messages" id="messages"></textarea>
 			</div>
 			<button type="submit" class="submit">Test</button>


### PR DESCRIPTION
## Summary
- fix spelled 'seperate' to 'separate'

## Testing
- `go version`