### PR TITLE
Fix typo in backfill thread worker comment

### DIFF
--- a/internal/background/backfill_thread_worker/worker.go
+++ b/internal/background/backfill_thread_worker/worker.go
@@ -30,7 +30,7 @@ func New(bot *internal.Bot, slackIntegration slack_integration.Integration) *Bac
 }
 
 func (w *BackfillThreadWorker) NextRetry(job *river.Job[background.BackfillThreadWorkerArgs]) time.Time {
-	// Most of the time failure is from slack API rate limiting, so backoff aggresively.
+	// Most of the time failure is from slack API rate limiting, so back off aggressively.
 	return time.Now().Add(30 * time.Second)
 }
 


### PR DESCRIPTION
## Summary
- fix typo in `NextRetry` comment in `backfill_thread_worker/worker.go`

## Testing
- `go fmt ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*