### PR TITLE
feat: add OTEL tracing to river workers and commands routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,4 +130,21 @@ Ratchet will respond to questions without waiting for explicit requests.
 ```bash
   curl http://localhost:5001/api/channels/ratchet-test/onboard -X POST
   curl http://localhost:5001/api/commands/generate?channel_id=FAKECHANNELID\&ts=1750324493.161329
+``
+
+### View Traces in Dev
+To enable tracing, add the following to your `.envrc` file:
+```sh
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http
+export OTEL_TRACES_SAMPLER=always_on
+export OTEL_SERVICE_NAME=ratchet
+export OTEL_RESOURCE_ATTRIBUTES=\
+service.version=1.2.3,\
+deployment.environment.name=dev
 ```
+
+To view traces, run Grafana and Tempo in Docker by following instructions in https://github.com/grafana/tempo/blob/main/example/docker-compose/readme.md. 
+You can delete the `k6-tracing` load generator service from the `docker-compose.yml` file.
+Then, you can access Grafana at `http://localhost:3000`.

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/cubicdaiya/gonp v1.0.4 // indirect
@@ -54,6 +55,7 @@ require (
 	github.com/google/cel-go v0.25.0 // indirect
 	github.com/google/go-github/v72 v72.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -86,6 +88,8 @@ require (
 	gitlab.com/golang-commonmark/markdown v0.0.0-20211110145824-bf3e522c626a // indirect
 	gitlab.com/golang-commonmark/mdurl v0.0.0-20191124015652-932350d1cb84 // indirect
 	gitlab.com/golang-commonmark/puny v0.0.0-20191124015043-9f83538fa04f // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476 // indirect
@@ -169,11 +173,11 @@ require (
 	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.36.0 // indirect
-	go.opentelemetry.io/otel/trace v1.36.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.36.0
+	go.opentelemetry.io/otel/trace v1.36.0
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/docker/docker v28.2.2+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/getsentry/sentry-go v0.33.0
+	github.com/getsentry/sentry-go v0.34.0
+	github.com/getsentry/sentry-go/otel v0.34.0
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/google/go-github/v53 v53.2.0
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
@@ -163,6 +164,7 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/riverqueue/river/riverdriver v0.23.1 // indirect
 	github.com/riverqueue/river/rivershared v0.23.1 // indirect
+	github.com/riverqueue/rivercontrib/otelriver v0.5.0
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/testcontainers/testcontainers-go v0.37.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,10 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=
 github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFAbguNaG7QCHcyGok=
-github.com/getsentry/sentry-go v0.33.0 h1:YWyDii0KGVov3xOaamOnF0mjOrqSjBqwv48UEzn7QFg=
-github.com/getsentry/sentry-go v0.33.0/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
+github.com/getsentry/sentry-go v0.34.0 h1:1FCHBVp8TfSc8L10zqSwXUZNiOSF+10qw4czjarTiY4=
+github.com/getsentry/sentry-go v0.34.0/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
+github.com/getsentry/sentry-go/otel v0.34.0 h1:8zz0z7rQI87TkfY92QlCeDxKyeNdmScPjiEgfJnHn0o=
+github.com/getsentry/sentry-go/otel v0.34.0/go.mod h1:Tt6M9onuYX+Cxxi7GZ90+BhJDAFlw2NRNQv9anTBt1M=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -275,6 +277,8 @@ github.com/riverqueue/river/rivershared v0.23.1 h1:ZC6ybv5KguD/mpLkaXrtUCES6FyKb
 github.com/riverqueue/river/rivershared v0.23.1/go.mod h1:8/jFVQNfUesv5y+qQZ55XULMCOdM5yj9F4MG7/UA8LA=
 github.com/riverqueue/river/rivertype v0.23.1 h1:vaIIm54BVzvy2iXT/iP7isIPSv2k99DElJNI6hWQ1lc=
 github.com/riverqueue/river/rivertype v0.23.1/go.mod h1:lmdl3vLNDfchDWbYdW2uAocIuwIN+ZaXqAukdSCFqWs=
+github.com/riverqueue/rivercontrib/otelriver v0.5.0 h1:dZF4Fy7/3RaIRsyCPdpIJtzEip0pCvoJ44YpSDum8e4=
+github.com/riverqueue/rivercontrib/otelriver v0.5.0/go.mod h1:rXANcBrlgRvg+auD3/O6Xfs59AWeWNpa/kim62mkxGo=
 github.com/riza-io/grpc-go v0.2.0 h1:2HxQKFVE7VuYstcJ8zqpN84VnAoJ4dCL6YFhJewNcHQ=
 github.com/riza-io/grpc-go v0.2.0/go.mod h1:2bDvR9KkKC3KhtlSHfR3dAXjUMT86kg4UfWFyVGWqi8=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=

--- a/go.sum
+++ b/go.sum
@@ -24,7 +24,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bradleyfalzon/ghinstallation/v2 v2.16.0 h1:B91r9bHtXp/+XRgS5aZm6ZzTdz3ahgJYmkt4xZkgDz8=
 github.com/bradleyfalzon/ghinstallation/v2 v2.16.0/go.mod h1:OeVe5ggFzoBnmgitZe/A+BqGOnv1DvU/0uiLQi1wutM=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=

--- a/internal/llm/mocks/mock_client.go
+++ b/internal/llm/mocks/mock_client.go
@@ -102,6 +102,21 @@ func (mr *MockClientMockRecorder) Model() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockClient)(nil).Model))
 }
 
+// RunChatCompletionWithTools mocks base method.
+func (m *MockClient) RunChatCompletionWithTools(ctx context.Context, messages []openai.ChatCompletionMessageParamUnion, tools []openai.ChatCompletionToolParam, parallelToolCalls bool) (*openai.ChatCompletion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunChatCompletionWithTools", ctx, messages, tools, parallelToolCalls)
+	ret0, _ := ret[0].(*openai.ChatCompletion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunChatCompletionWithTools indicates an expected call of RunChatCompletionWithTools.
+func (mr *MockClientMockRecorder) RunChatCompletionWithTools(ctx, messages, tools, parallelToolCalls any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunChatCompletionWithTools", reflect.TypeOf((*MockClient)(nil).RunChatCompletionWithTools), ctx, messages, tools, parallelToolCalls)
+}
+
 // RunJSONModePrompt mocks base method.
 func (m *MockClient) RunJSONModePrompt(ctx context.Context, prompt string, schema *jsonschema.Schema) (string, string, error) {
 	m.ctrl.T.Helper()

--- a/internal/modules/commands/cmds.go
+++ b/internal/modules/commands/cmds.go
@@ -107,8 +107,11 @@ func (c *Commands) OnThreadMessage(ctx context.Context, channelID string, slackT
 func (c *Commands) Generate(ctx context.Context, channelID string, slackTS string, msg dto.MessageAttrs, force bool) (string, error) {
 	ctx, span := c.tracer.Start(ctx, "commands.generate",
 		trace.WithAttributes(
-			attribute.String("channel.id", channelID),
-			attribute.String("slack.ts", slackTS),
+			attribute.String("slack_user", msg.Message.User),
+			attribute.String("channel_id", channelID),
+			attribute.String("slack_ts", slackTS),
+			attribute.Bool("force", force),
+			attribute.Bool("force_trace", force),
 		),
 	)
 	defer span.End()
@@ -383,8 +386,11 @@ func (c *Commands) getThreadMessages(ctx context.Context, channelID string, slac
 func (c *Commands) Respond(ctx context.Context, channelID string, slackTS string, msg dto.MessageAttrs, force bool) error {
 	ctx, span := c.tracer.Start(ctx, "commands.respond",
 		trace.WithAttributes(
-			attribute.String("channel.id", channelID),
-			attribute.String("slack.ts", slackTS),
+			attribute.String("slack_user", msg.Message.User),
+			attribute.String("channel_id", channelID),
+			attribute.String("slack_ts", slackTS),
+			attribute.Bool("force", force),
+			attribute.Bool("force_trace", force),
 		),
 	)
 	defer span.End()

--- a/internal/otel/trace/sampler.go
+++ b/internal/otel/trace/sampler.go
@@ -1,0 +1,38 @@
+package trace
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// forceBasedSampler is a custom OpenTelemetry trace sampler that samples 100% of traces with force=true attribute
+// and uses default sampling rate for all other traces
+type forceBasedSampler struct {
+	defaultSampler sdkTrace.Sampler
+}
+
+func NewForceBasedSampler(defaultSampleRate float64) sdkTrace.Sampler {
+	return &forceBasedSampler{
+		defaultSampler: sdkTrace.ParentBased(sdkTrace.TraceIDRatioBased(defaultSampleRate)),
+	}
+}
+
+func (s *forceBasedSampler) ShouldSample(parameters sdkTrace.SamplingParameters) sdkTrace.SamplingResult {
+	for _, attr := range parameters.Attributes {
+		if attr.Key == "force" && attr.Value.AsBool() {
+			return sdkTrace.SamplingResult{
+				Decision:   sdkTrace.RecordAndSample,
+				Attributes: []attribute.KeyValue{},
+			}
+		}
+	}
+
+	return s.defaultSampler.ShouldSample(parameters)
+}
+
+
+func (s *forceBasedSampler) Description() string {
+	return fmt.Sprintf("ForceBasedSampler{default=%s}", s.defaultSampler.Description())
+}

--- a/internal/web/http.go
+++ b/internal/web/http.go
@@ -15,6 +15,9 @@ import (
 	"github.com/earthboundkid/versioninfo/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"riverqueue.com/riverui"
 
 	"github.com/dynoinc/ratchet/internal"
@@ -122,8 +125,8 @@ func New(
 	apiMux.HandleFunc("POST /services/{service}/alerts/{alert}/post-runbook", handleJSON(handlers.postRunbook))
 
 	// Commands
-	apiMux.HandleFunc("GET /commands/generate", handlers.generateCommand)
-	apiMux.HandleFunc("POST /commands/respond", handlers.respondCommand)
+	apiMux.HandleFunc("GET /commands/generate", otelhttp.NewHandler(http.HandlerFunc(handlers.generateCommand), "commands-generate").ServeHTTP)
+	apiMux.HandleFunc("POST /commands/respond", otelhttp.NewHandler(http.HandlerFunc(handlers.respondCommand), "commands-respond").ServeHTTP)
 
 	// Documentation
 	apiMux.HandleFunc("GET /docs/status", handleJSON(handlers.docsStatus))
@@ -137,6 +140,7 @@ func New(
 	mux.Handle("GET /version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(versioninfo.Short()))
 	}))
+
 	return mux, nil
 }
 
@@ -387,6 +391,9 @@ func (h *httpHandlers) postRefresh(r *http.Request) (any, error) {
 }
 
 func (h *httpHandlers) generateCommand(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.Bool("force_trace", true))
 	channelID := r.URL.Query().Get("channel_id")
 	threadTS := r.URL.Query().Get("ts")
 	if channelID == "" || threadTS == "" {
@@ -394,23 +401,28 @@ func (h *httpHandlers) generateCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	msg, err := h.bot.GetMessage(r.Context(), channelID, threadTS)
+	msg, err := h.bot.GetMessage(ctx, channelID, threadTS)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("getting message: %v", err), http.StatusInternalServerError)
 		return
 	}
+	span.SetAttributes(attribute.String("user", msg.Attrs.Message.User), attribute.String("channel.id", msg.ChannelID), attribute.String("slack.ts", msg.Ts))
 
-	response, err := h.commands.Generate(r.Context(), channelID, threadTS, msg.Attrs, true /* force */)
+	response, err := h.commands.Generate(ctx, channelID, threadTS, msg.Attrs, true /* force */)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("generating command: %v", err), http.StatusInternalServerError)
 		return
 	}
+	span.SetAttributes(attribute.Int("response.message.size", len(response)))
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.Write([]byte(response))
 }
 
 func (h *httpHandlers) respondCommand(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.Bool("force_trace", true))
 	channelID := r.URL.Query().Get("channel_id")
 	threadTS := r.URL.Query().Get("ts")
 	if channelID == "" || threadTS == "" {
@@ -418,7 +430,7 @@ func (h *httpHandlers) respondCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	msg, err := h.bot.GetMessage(r.Context(), channelID, threadTS)
+	msg, err := h.bot.GetMessage(ctx, channelID, threadTS)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			http.Error(w, "message not found", http.StatusNotFound)
@@ -428,8 +440,9 @@ func (h *httpHandlers) respondCommand(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("getting message: %v", err), http.StatusInternalServerError)
 		return
 	}
+	span.SetAttributes(attribute.String("user", msg.Attrs.Message.User), attribute.String("channel.id", msg.ChannelID), attribute.String("slack.ts", msg.Ts))
 
-	err = h.commands.Respond(r.Context(), channelID, threadTS, msg.Attrs, true /* force */)
+	err = h.commands.Respond(ctx, channelID, threadTS, msg.Attrs, true /* force */)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("generating command: %v", err), http.StatusInternalServerError)
 		return

--- a/internal/web/http.go
+++ b/internal/web/http.go
@@ -393,7 +393,6 @@ func (h *httpHandlers) postRefresh(r *http.Request) (any, error) {
 func (h *httpHandlers) generateCommand(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(attribute.Bool("force_trace", true))
 	channelID := r.URL.Query().Get("channel_id")
 	threadTS := r.URL.Query().Get("ts")
 	if channelID == "" || threadTS == "" {
@@ -422,7 +421,6 @@ func (h *httpHandlers) generateCommand(w http.ResponseWriter, r *http.Request) {
 func (h *httpHandlers) respondCommand(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(attribute.Bool("force_trace", true))
 	channelID := r.URL.Query().Get("channel_id")
 	threadTS := r.URL.Query().Get("ts")
 	if channelID == "" || threadTS == "" {


### PR DESCRIPTION
- Existing Sentry spans removed
- OTEL Tracer will be used for Sentry too, so traces will also be sent to Sentry in addition to an OTEL endpoint
- For now, traces are created for river worker jobs using https://riverqueue.com/docs/open-telemetry and /api/commands/* routes using `otelhttp.NewHandler`
- Sampling rate is set to 100% if the `force_trace=true` attr is added to a span when it's created, otherwise it defaults to the new `TraceSampleRate` config
- Force trace attr is added to agent responses for 100% tail sampling
- Add instructions on viewing traces in dev environment