### PR TITLE
feat: add openai middleware for tracing

### DIFF
--- a/.cursor/rules/otel.mdc
+++ b/.cursor/rules/otel.mdc
@@ -1,0 +1,14 @@
+---
+description: 
+globs: *.go
+alwaysApply: false
+---
+# OpenTelemetry Library
+When using the OpenTelemetry library from a package in the namespace `go.opentelemetry.io/otel`, follow these guidelines
+
+When adding an attribute
+- Attribute key: create a const for the `attribute.Key`, DO NOT use a literal string for the key
+    - Standard keys: If the attribute key is already used in the OTEL semantic conventions, use the key defined in `go.opentelemetry.io/otel/semconv/v1.26.0`. Always use the latest version of `semconv` 
+    - Custom keys: otherwise, for custom keys not defined in the `semconv` library 
+        - If the key is only used in the package, keep the const in the package
+        - If the key is used across the codebase, add it to `internal/otel/semconv/attributes.go`

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/shared"
 	"github.com/qri-io/jsonschema"
+	"go.opentelemetry.io/otel"
 
 	"github.com/dynoinc/ratchet/internal/storage/schema"
 	"github.com/dynoinc/ratchet/internal/storage/schema/dto"
@@ -242,6 +243,8 @@ func New(ctx context.Context, cfg Config, db *pgxpool.Pool) (Client, error) {
 		option.WithBaseURL(cfg.URL),
 		option.WithAPIKey(cfg.APIKey),
 		option.WithMiddleware(persistLLMUsageMiddleware(db)),
+		// This MUST be last, otherwise it will measure other middleware
+		option.WithMiddleware(NewOtelMiddleware(otel.GetTracerProvider(), OtelMiddlewareConfig{AddEventDetails: true})),
 	)
 
 	// Check and download the main model if needed

--- a/internal/llm/otel_middleware.go
+++ b/internal/llm/otel_middleware.go
@@ -1,0 +1,485 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Semantic conventions not in Go OpenTelemetry library yet, because they're not stable yet
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/openai
+const (
+	GenAISystemKey                  = attribute.Key("gen_ai.system")
+	GenAIOperationNameKey           = attribute.Key("gen_ai.operation.name")
+	GenAIRequestModelKey            = attribute.Key("gen_ai.request.model")
+	GenAIResponseModelKey           = attribute.Key("gen_ai.response.model")
+	GenAIUsageInputTokensKey        = attribute.Key("gen_ai.usage.input_tokens")
+	GenAIUsageOutputTokensKey       = attribute.Key("gen_ai.usage.output_tokens")
+	GenAIRequestTemperatureKey      = attribute.Key("gen_ai.request.temperature")
+	GenAIRequestMaxTokensKey        = attribute.Key("gen_ai.request.max_tokens")
+	GenAIRequestTopPKey             = attribute.Key("gen_ai.request.top_p")
+	GenAIRequestFrequencyPenaltyKey = attribute.Key("gen_ai.request.frequency_penalty")
+	GenAIRequestPresencePenaltyKey  = attribute.Key("gen_ai.request.presence_penalty")
+	GenAIRequestEncodingFormatsKey  = attribute.Key("gen_ai.request.encoding_formats")
+	GenAIResponseIDKey              = attribute.Key("gen_ai.response.id")
+	GenAIResponseFinishReasonKey    = attribute.Key("gen_ai.response.finish_reason")
+	GenAIResponseFinishReasonsKey   = attribute.Key("gen_ai.response.finish_reasons")
+
+	// Tool execution attributes
+	// https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span
+	GenAIToolNameKey        = attribute.Key("gen_ai.tool.name")
+	GenAIToolCallIDKey      = attribute.Key("gen_ai.tool.call.id")
+	GenAIToolDescriptionKey = attribute.Key("gen_ai.tool.description")
+
+	// Span events
+	// https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events
+	GenAiSystemMessageKey    = "gen_ai.system.message"
+	GenAiUserMessageKey      = "gen_ai.user.message"
+	GenAiAssistantMessageKey = "gen_ai.assistant.message"
+	GenAiChoiceKey           = "gen_ai.choice"
+	GenAiMessageContentKey   = attribute.Key("content")
+	GenAiToolCallsKey        = attribute.Key("tool_calls")
+)
+
+var (
+	// Gen AI attribute values
+	GenAISystemOpenAI = GenAISystemKey.String("openai")
+)
+
+type Operation string
+
+const (
+	OperationChat        Operation = "chat"
+	OperationEmbeddings  Operation = "embeddings"
+	OperationExecuteTool Operation = "execute_tool"
+)
+
+type OtelMiddlewareConfig struct {
+	AddEventDetails bool
+	SampleRoot      bool
+}
+
+func NewOtelMiddleware(tracerProvider trace.TracerProvider, config OtelMiddlewareConfig) option.Middleware {
+	tracer := tracerProvider.Tracer("openai.otel.middleware")
+
+	return func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+		parentSpan := trace.SpanFromContext(req.Context())
+		if !config.SampleRoot && (parentSpan == nil || !parentSpan.SpanContext().IsValid()) {
+			return next(req)
+		}
+
+		operation, err := getOperationFromPath(req.URL.Path)
+		excludeGenAi := false
+		if err != nil {
+			if err == ErrUnsupportedOperation {
+				excludeGenAi = true
+			} else {
+				return next(req)
+			}
+		}
+
+		var reqBody []byte
+		if req.Body != nil && req.Method == "POST" {
+			var err error
+			reqBody, err = io.ReadAll(req.Body)
+			if err == nil {
+				req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+			} else {
+				return next(req)
+			}
+		}
+
+		var model RequestSpanHydrator
+		if len(reqBody) > 0 {
+			model, err = extractRequestModel(operation, reqBody)
+			if err != nil {
+				if err == ErrModelNotFound {
+					excludeGenAi = true
+				} else {
+					return next(req)
+				}
+			}
+		}
+
+		attributes := []attribute.KeyValue{}
+		if operation != "" {
+			attributes = append(attributes, GenAIOperationNameKey.String(string(operation)))
+		}
+
+		// Add server attributes
+		if req.URL.Host != "" {
+			attributes = append(attributes, semconv.ServerAddress(req.URL.Hostname()))
+			if port := req.URL.Port(); port != "" {
+				if portInt, err := strconv.Atoi(port); err == nil {
+					attributes = append(attributes, semconv.ServerPort(portInt))
+				}
+			}
+		}
+
+		// Add HTTP attributes
+		attributes = append(attributes,
+			semconv.HTTPRequestMethodKey.String(req.Method),
+			semconv.URLFull(req.URL.String()),
+		)
+
+		spanName := ""
+		if !excludeGenAi && model != nil {
+			// Required Gen AI attributes
+			attributes = append(attributes, []attribute.KeyValue{
+				GenAISystemOpenAI,
+				GenAIRequestModelKey.String(model.ModelName()),
+			}...)
+			// Add Gen AI request attributes from model
+			attributes = append(attributes, model.SpanAttributes()...)
+			spanName = fmt.Sprintf("%s %s", operation, model.ModelName())
+		} else {
+			// For operations that aren't supported by this middleware yet, fallback to only HTTP metadata
+			spanName = fmt.Sprintf("%s %s", req.Method, req.URL.Path)
+		}
+
+		ctx, span := tracer.Start(req.Context(), spanName, trace.WithAttributes(attributes...), trace.WithSpanKind(trace.SpanKindClient))
+		defer span.End()
+
+		// Add span events from model
+		if !excludeGenAi && model != nil {
+			model.AddSpanEvents(span, config.AddEventDetails)
+		}
+
+		// Execute the request
+		resp, err := next(req.WithContext(ctx))
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			span.SetAttributes(semconv.ErrorTypeKey.String(reflect.TypeOf(err).String()))
+			return resp, err
+		}
+
+		// Hydrate span from response
+		hydrateSpanFromResponse(span, resp, operation, config)
+		return resp, err
+	}
+}
+
+var ErrUnsupportedOperation = fmt.Errorf("unsupported operation")
+var ErrModelNotFound = fmt.Errorf("model not found")
+
+func getOperationFromPath(path string) (Operation, error) {
+	if strings.Contains(path, "/chat/completions") {
+		return OperationChat, nil
+	} else if strings.Contains(path, "/embeddings") {
+		return OperationEmbeddings, nil
+	}
+	return "", ErrUnsupportedOperation
+}
+
+// Extract request model as RequestSpanHydrator
+func extractRequestModel(operation Operation, reqBody []byte) (RequestSpanHydrator, error) {
+	if len(reqBody) == 0 {
+		return nil, ErrModelNotFound
+	}
+	switch operation {
+	case OperationChat:
+		var chatParams chatCompletionParams
+		if err := json.Unmarshal(reqBody, &chatParams); err != nil {
+			return nil, err
+		} else {
+			return &chatParams, nil
+		}
+	case OperationEmbeddings:
+		var embeddingParams embeddingParams
+		if err := json.Unmarshal(reqBody, &embeddingParams); err != nil {
+			return nil, err
+		} else {
+			return &embeddingParams, nil
+		}
+	}
+	return nil, ErrModelNotFound
+}
+
+// Interface for extracting span metadata from request models
+type RequestSpanHydrator interface {
+	ModelName() string
+	SpanAttributes() []attribute.KeyValue
+	AddSpanEvents(span trace.Span, includeDetails bool)
+}
+
+type chatCompletionParams struct {
+	openai.ChatCompletionNewParams
+}
+
+func (c *chatCompletionParams) ModelName() string {
+	return c.Model
+}
+
+func (c *chatCompletionParams) SpanAttributes() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+	if c.Temperature.Valid() {
+		attrs = append(attrs, GenAIRequestTemperatureKey.Float64(c.Temperature.Value))
+	}
+	if c.MaxTokens.Valid() {
+		attrs = append(attrs, GenAIRequestMaxTokensKey.Int64(c.MaxTokens.Value))
+	}
+	if c.TopP.Valid() {
+		attrs = append(attrs, GenAIRequestTopPKey.Float64(c.TopP.Value))
+	}
+	if c.FrequencyPenalty.Valid() {
+		attrs = append(attrs, GenAIRequestFrequencyPenaltyKey.Float64(c.FrequencyPenalty.Value))
+	}
+	if c.PresencePenalty.Valid() {
+		attrs = append(attrs, GenAIRequestPresencePenaltyKey.Float64(c.PresencePenalty.Value))
+	}
+	return attrs
+}
+
+func (c *chatCompletionParams) AddSpanEvents(span trace.Span, includeDetails bool) {
+	for _, msg := range c.Messages {
+		attrs := []attribute.KeyValue{
+			GenAISystemOpenAI,
+		}
+		if msg.OfSystem != nil && msg.OfSystem.Content.OfString.Valid() {
+			if includeDetails {
+				content := msg.OfSystem.Content.OfString.Value
+				attrs = append(attrs, GenAiMessageContentKey.String(content))
+			}
+			span.AddEvent(GenAiSystemMessageKey, trace.WithAttributes(attrs...))
+		} else if msg.OfUser != nil && msg.OfUser.Content.OfString.Valid() {
+			if includeDetails {
+				content := msg.OfUser.Content.OfString.Value
+				attrs = append(attrs, GenAiMessageContentKey.String(content))
+			}
+			span.AddEvent(GenAiUserMessageKey, trace.WithAttributes(attrs...))
+		} else if msg.OfAssistant != nil && msg.OfAssistant.Content.OfString.Valid() {
+			if includeDetails {
+				content := msg.OfAssistant.Content.OfString.Value
+				attrs = append(attrs, GenAiMessageContentKey.String(content))
+			}
+			if len(msg.OfAssistant.ToolCalls) > 0 {
+				toolCallsMap := serializeToolCallParams(msg.OfAssistant.ToolCalls, includeDetails)
+				if toolCallsJSON, err := json.Marshal(toolCallsMap); err == nil {
+					attrs = append(attrs, GenAiToolCallsKey.String(string(toolCallsJSON)))
+				}
+			}
+			span.AddEvent(GenAiAssistantMessageKey, trace.WithAttributes(attrs...))
+		}
+	}
+}
+
+type embeddingParams struct {
+	openai.EmbeddingNewParams
+}
+
+func (e *embeddingParams) ModelName() string {
+	return e.Model
+}
+
+func (e *embeddingParams) SpanAttributes() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+	attrs = append(attrs, GenAIRequestEncodingFormatsKey.String(string(e.EncodingFormat)))
+	return attrs
+}
+
+func (e *embeddingParams) AddSpanEvents(span trace.Span, includeDetails bool) {
+	// No-op for embeddings
+}
+
+func hydrateSpanFromResponse(span trace.Span, resp *http.Response, operation Operation, config OtelMiddlewareConfig) {
+	if resp == nil {
+		return
+	}
+
+	// Add HTTP response attributes
+	span.SetAttributes(
+		semconv.HTTPResponseStatusCode(resp.StatusCode),
+	)
+
+	if resp.StatusCode >= 400 {
+		span.SetStatus(codes.Error, "")
+		span.SetAttributes(semconv.ErrorTypeKey.String(fmt.Sprintf("%d", resp.StatusCode)))
+	}
+	if resp.StatusCode >= 300 {
+		return
+	}
+
+	if resp.Body != nil {
+		respBody, err := io.ReadAll(resp.Body)
+		if err == nil {
+			resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
+
+			responseModel, _ := extractResponseModel(operation, respBody)
+			if responseModel != nil {
+				for _, attr := range responseModel.SpanAttributes() {
+					span.SetAttributes(attr)
+				}
+				responseModel.AddSpanEvents(span, config.AddEventDetails)
+			}
+		}
+	}
+}
+
+// Extract response model as ResponseSpanHydrator
+func extractResponseModel(operation Operation, respBody []byte) (ResponseSpanHydrator, error) {
+	if len(respBody) == 0 {
+		return nil, ErrModelNotFound
+	}
+	switch operation {
+	case OperationChat:
+		var chatResp openai.ChatCompletion
+		if err := json.Unmarshal(respBody, &chatResp); err != nil {
+			return nil, err
+		}
+		params := &chatCompletionResponseParams{
+			ChatCompletion: chatResp,
+		}
+		return params, nil
+	case OperationEmbeddings:
+		var embeddingResp openai.CreateEmbeddingResponse
+		if err := json.Unmarshal(respBody, &embeddingResp); err != nil {
+			return nil, err
+		}
+		params := &embeddingResponseParams{
+			CreateEmbeddingResponse: embeddingResp,
+		}
+		return params, nil
+	}
+	return nil, ErrModelNotFound
+}
+
+// Interface for extracting span metadata from response models
+type ResponseSpanHydrator interface {
+	SpanAttributes() []attribute.KeyValue
+	AddSpanEvents(span trace.Span, includeDetails bool)
+}
+
+type chatCompletionResponseParams struct {
+	openai.ChatCompletion
+}
+
+func (c *chatCompletionResponseParams) SpanAttributes() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+	if c.ChatCompletion.Model != "" {
+		attrs = append(attrs, GenAIResponseModelKey.String(c.ChatCompletion.Model))
+	}
+	if c.ChatCompletion.ID != "" {
+		attrs = append(attrs, GenAIResponseIDKey.String(c.ChatCompletion.ID))
+	}
+	if c.ChatCompletion.Usage.PromptTokens > 0 {
+		attrs = append(attrs, GenAIUsageInputTokensKey.Int64(c.ChatCompletion.Usage.PromptTokens))
+	}
+	if c.ChatCompletion.Usage.CompletionTokens > 0 {
+		attrs = append(attrs, GenAIUsageOutputTokensKey.Int64(c.ChatCompletion.Usage.CompletionTokens))
+	}
+	if len(c.ChatCompletion.Choices) > 0 {
+		finishReasons := make([]string, 0, len(c.ChatCompletion.Choices))
+		for _, choice := range c.ChatCompletion.Choices {
+			if choice.FinishReason != "" {
+				finishReasons = append(finishReasons, choice.FinishReason)
+			}
+		}
+		if len(finishReasons) > 0 {
+			attrs = append(attrs, GenAIResponseFinishReasonsKey.StringSlice(finishReasons))
+		}
+	}
+	return attrs
+}
+
+type toolCallFunctionData struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+type toolCallData struct {
+	ID       string               `json:"id"`
+	Type     string               `json:"type"`
+	Function toolCallFunctionData `json:"function"`
+}
+
+func (c *chatCompletionResponseParams) AddSpanEvents(span trace.Span, includeDetails bool) {
+	for _, choice := range c.ChatCompletion.Choices {
+		attrs := []attribute.KeyValue{
+			GenAISystemOpenAI,
+			attribute.Key("index").Int64(choice.Index),
+		}
+		if choice.FinishReason != "" {
+			attrs = append(attrs, GenAIResponseFinishReasonKey.String(choice.FinishReason))
+		}
+		if includeDetails && choice.Message.Content != "" {
+			// Map attribute types not supported by OpenTelemetry yet, so just set content attribute
+			attrs = append(attrs, GenAiMessageContentKey.String(choice.Message.Content))
+		}
+
+		// Map attribute types not supported by OpenTelemetry yet, so just marshall to JSON string
+		if len(choice.Message.ToolCalls) > 0 {
+			toolCallsMap := serializeToolCalls(choice.Message.ToolCalls, includeDetails)
+			if toolCallsJSON, err := json.Marshal(toolCallsMap); err == nil {
+				attrs = append(attrs, GenAiToolCallsKey.String(string(toolCallsJSON)))
+			}
+		}
+
+		span.AddEvent(GenAiChoiceKey, trace.WithAttributes(attrs...))
+	}
+}
+
+func serializeToolCallParams(toolCalls []openai.ChatCompletionMessageToolCallParam, includeDetails bool) map[string]toolCallData {
+	toolCallsMap := make(map[string]toolCallData)
+	for _, toolCall := range toolCalls {
+		function := toolCallFunctionData{
+			Name: toolCall.Function.Name,
+		}
+		if includeDetails {
+			function.Arguments = toolCall.Function.Arguments
+		}
+		data := toolCallData{
+			ID:       toolCall.ID,
+			Type:     string(toolCall.Type),
+			Function: function,
+		}
+		toolCallsMap[toolCall.ID] = data
+	}
+	return toolCallsMap
+}
+
+func serializeToolCalls(toolCalls []openai.ChatCompletionMessageToolCall, includeDetails bool) map[string]toolCallData {
+	toolCallsMap := make(map[string]toolCallData)
+	for _, toolCall := range toolCalls {
+		function := toolCallFunctionData{
+			Name: toolCall.Function.Name,
+		}
+		if includeDetails {
+			function.Arguments = toolCall.Function.Arguments
+		}
+		data := toolCallData{
+			ID:       toolCall.ID,
+			Type:     string(toolCall.Type),
+			Function: function,
+		}
+		toolCallsMap[toolCall.ID] = data
+	}
+	return toolCallsMap
+}
+
+type embeddingResponseParams struct {
+	openai.CreateEmbeddingResponse
+}
+
+func (e *embeddingResponseParams) SpanAttributes() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+	attrs = append(attrs, GenAIUsageInputTokensKey.Int64(e.CreateEmbeddingResponse.Usage.PromptTokens))
+	return attrs
+}
+
+func (e *embeddingResponseParams) AddSpanEvents(span trace.Span, includeDetails bool) {
+	// No-op
+}

--- a/internal/llm/otel_middleware_test.go
+++ b/internal/llm/otel_middleware_test.go
@@ -1,0 +1,746 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/packages/param"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// SetupTest consolidates reusable test fixtures for otel middleware tests.
+type TestEnv struct {
+	SpanRecorder   *tracetest.SpanRecorder
+	TracerProvider *trace.TracerProvider
+	TestServer     *httptest.Server
+	Client         openai.Client
+}
+
+func SetupTest(t *testing.T, handler http.HandlerFunc, config OtelMiddlewareConfig, extraMiddleware ...option.Middleware) *TestEnv {
+	config.SampleRoot = true
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
+	testServer := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		spanRecorder.Reset()
+		testServer.Close()
+	})
+
+	allMiddleware := []option.Middleware{
+		NewOtelMiddleware(tp, config),
+	}
+	allMiddleware = append(allMiddleware, extraMiddleware...)
+
+	clientOptions := []option.RequestOption{
+		option.WithBaseURL(testServer.URL),
+		option.WithAPIKey("test-key"),
+		option.WithMiddleware(allMiddleware...),
+	}
+
+	client := openai.NewClient(clientOptions...)
+	return &TestEnv{
+		SpanRecorder:   spanRecorder,
+		TracerProvider: tp,
+		TestServer:     testServer,
+		Client:         client,
+	}
+}
+
+func TestOtelMiddleware_ChatCompletion(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := openai.ChatCompletion{
+			ID:    "chatcmpl-123",
+			Model: "gpt-4",
+			Choices: []openai.ChatCompletionChoice{{
+				Message: openai.ChatCompletionMessage{
+					Role:    "assistant",
+					Content: "Hello! How can I help you today?",
+				},
+				FinishReason: "stop",
+			}},
+			Usage: openai.CompletionUsage{
+				PromptTokens:     10,
+				CompletionTokens: 9,
+				TotalTokens:      19,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	})
+	env := SetupTest(t, handler, OtelMiddlewareConfig{})
+	client := env.Client
+	spanRecorder := env.SpanRecorder
+
+	// Create a chat completion request
+	ctx := context.Background()
+	params := openai.ChatCompletionNewParams{
+		Model: "gpt-4",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{
+				OfUser: &openai.ChatCompletionUserMessageParam{
+					Content: openai.ChatCompletionUserMessageParamContentUnion{
+						OfString: param.NewOpt("Hello"),
+					},
+				},
+			},
+		},
+		Temperature: param.NewOpt(0.7),
+		MaxTokens:   param.NewOpt[int64](100),
+	}
+
+	// Make the request
+	_, err := client.Chat.Completions.New(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to make chat completion request: %v", err)
+	}
+
+	// Verify the span was created and properly hydrated
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("No spans were recorded")
+	}
+
+	span := spans[0]
+
+	// Check span name follows Gen AI convention
+	if span.Name() != "chat gpt-4" {
+		t.Errorf("Expected span name 'chat gpt-4', got '%s'", span.Name())
+	}
+
+	// Check Gen AI attributes
+	attrs := span.Attributes()
+	expectedAttrs := map[attribute.Key]interface{}{
+		GenAISystemKey:            "openai",
+		GenAIOperationNameKey:     "chat",
+		GenAIRequestModelKey:      "gpt-4",
+		GenAIResponseModelKey:     "gpt-4",
+		GenAIUsageInputTokensKey:  int64(10),
+		GenAIUsageOutputTokensKey: int64(9),
+	}
+
+	for expectedKey, expectedValue := range expectedAttrs {
+		found := false
+		for _, attr := range attrs {
+			if attr.Key == expectedKey {
+				found = true
+				switch expectedValue := expectedValue.(type) {
+				case string:
+					if attr.Value.AsString() != expectedValue {
+						t.Errorf("Expected %s='%v', got '%v'", expectedKey, expectedValue, attr.Value.AsString())
+					}
+				case int64:
+					if attr.Value.AsInt64() != expectedValue {
+						t.Errorf("Expected %s=%v, got %v", expectedKey, expectedValue, attr.Value.AsInt64())
+					}
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Missing expected attribute: %s", expectedKey)
+		}
+	}
+
+	// Check additional attributes
+	hasTemperature := false
+	hasMaxTokens := false
+	hasResponseID := false
+	hasFinishReasons := false
+	var finishReasons []string
+
+	for _, attr := range attrs {
+		switch attr.Key {
+		case "gen_ai.request.temperature":
+			hasTemperature = true
+			if attr.Value.AsFloat64() != 0.7 {
+				t.Errorf("Expected temperature=0.7, got %v", attr.Value.AsFloat64())
+			}
+		case "gen_ai.request.max_tokens":
+			hasMaxTokens = true
+			if attr.Value.AsInt64() != 100 {
+				t.Errorf("Expected max_tokens=100, got %v", attr.Value.AsInt64())
+			}
+		case "gen_ai.response.id":
+			hasResponseID = true
+			if attr.Value.AsString() != "chatcmpl-123" {
+				t.Errorf("Expected response_id='chatcmpl-123', got '%v'", attr.Value.AsString())
+			}
+		case "gen_ai.response.finish_reasons":
+			hasFinishReasons = true
+			finishReasons = attr.Value.AsStringSlice()
+		}
+	}
+
+	if !hasTemperature {
+		t.Error("Missing gen_ai.request.temperature attribute")
+	}
+	if !hasMaxTokens {
+		t.Error("Missing gen_ai.request.max_tokens attribute")
+	}
+	if !hasResponseID {
+		t.Error("Missing gen_ai.response.id attribute")
+	}
+	if !hasFinishReasons {
+		t.Error("Missing gen_ai.response.finish_reasons attribute")
+	} else {
+		expected := []string{"stop"}
+		if len(finishReasons) != len(expected) {
+			t.Errorf("Expected finish_reasons length %d, got %d", len(expected), len(finishReasons))
+		} else {
+			for i, v := range expected {
+				if finishReasons[i] != v {
+					t.Errorf("Expected finish_reasons[%d]='%s', got '%s'", i, v, finishReasons[i])
+				}
+			}
+		}
+	}
+}
+
+func TestOtelMiddleware_EmbeddingRequest(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := openai.CreateEmbeddingResponse{
+			Data: []openai.Embedding{{
+				Embedding: []float64{0.1, 0.2, 0.3},
+				Index:     0,
+			}},
+			Model: "text-embedding-ada-002",
+			Usage: openai.CreateEmbeddingResponseUsage{
+				PromptTokens: 5,
+				TotalTokens:  5,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	})
+	env := SetupTest(t, handler, OtelMiddlewareConfig{})
+	client := env.Client
+	spanRecorder := env.SpanRecorder
+
+	// Create an embedding request
+	ctx := context.Background()
+	params := openai.EmbeddingNewParams{
+		Model: "text-embedding-ada-002",
+		Input: openai.EmbeddingNewParamsInputUnion{
+			OfString: param.NewOpt("Hello world"),
+		},
+		Dimensions: param.NewOpt[int64](3),
+	}
+
+	// Make the request
+	_, err := client.Embeddings.New(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to make embedding request: %v", err)
+	}
+
+	// Verify the span was created and properly hydrated
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("No spans were recorded")
+	}
+
+	span := spans[0]
+
+	// Check span name follows Gen AI convention
+	if span.Name() != "embeddings text-embedding-ada-002" {
+		t.Errorf("Expected span name 'embeddings text-embedding-ada-002', got '%s'", span.Name())
+	}
+
+	// Check Gen AI attributes
+	attrs := span.Attributes()
+	expectedAttrs := map[attribute.Key]interface{}{
+		GenAISystemKey:           "openai",
+		GenAIOperationNameKey:    "embeddings",
+		GenAIRequestModelKey:     "text-embedding-ada-002",
+		GenAIUsageInputTokensKey: int64(5),
+	}
+
+	for expectedKey, expectedValue := range expectedAttrs {
+		found := false
+		for _, attr := range attrs {
+			if attr.Key == expectedKey {
+				found = true
+				switch expectedValue := expectedValue.(type) {
+				case string:
+					if attr.Value.AsString() != expectedValue {
+						t.Errorf("Expected %s='%v', got '%v'", expectedKey, expectedValue, attr.Value.AsString())
+					}
+				case int64:
+					if attr.Value.AsInt64() != expectedValue {
+						t.Errorf("Expected %s=%v, got %v", expectedKey, expectedValue, attr.Value.AsInt64())
+					}
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Missing expected attribute: %s", expectedKey)
+		}
+	}
+}
+
+func TestGetOperationFromPath(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected Operation
+		wantErr  bool
+	}{
+		{"/v1/chat/completions", OperationChat, false},
+		{"/chat/completions", OperationChat, false},
+		{"/v1/embeddings", OperationEmbeddings, false},
+		{"/embeddings", OperationEmbeddings, false},
+		{"/unknown/path", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			result, err := getOperationFromPath(tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("getOperationFromPath(%q) expected error, got none", tt.path)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("getOperationFromPath(%q) unexpected error: %v", tt.path, err)
+				}
+				if result != tt.expected {
+					t.Errorf("getOperationFromPath(%q) = %q, want %q", tt.path, result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestOtelMiddleware_ChatCompletion_EmitsGenAIChoiceEvents(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := openai.ChatCompletion{
+			ID:    "chatcmpl-456",
+			Model: "gpt-4",
+			Choices: []openai.ChatCompletionChoice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: openai.ChatCompletionMessage{
+						Role:    "assistant",
+						Content: "First response",
+					},
+				},
+				{
+					Index:        1,
+					FinishReason: "length",
+					Message: openai.ChatCompletionMessage{
+						Role:    "assistant",
+						Content: "Second response",
+					},
+				},
+			},
+			Usage: openai.CompletionUsage{
+				PromptTokens:     5,
+				CompletionTokens: 7,
+				TotalTokens:      12,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	})
+	env := SetupTest(t, handler, OtelMiddlewareConfig{AddEventDetails: true})
+	client := env.Client
+	spanRecorder := env.SpanRecorder
+
+	// Create a chat completion request
+	ctx := context.Background()
+	params := openai.ChatCompletionNewParams{
+		Model: "gpt-4",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{
+				OfUser: &openai.ChatCompletionUserMessageParam{
+					Content: openai.ChatCompletionUserMessageParamContentUnion{
+						OfString: param.NewOpt("Hi!"),
+					},
+				},
+			},
+		},
+	}
+
+	// Make the request
+	_, err := client.Chat.Completions.New(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to make chat completion request: %v", err)
+	}
+
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("No spans were recorded")
+	}
+
+	span := spans[0]
+	events := span.Events()
+	var foundChoice0, foundChoice1 bool
+	for _, ev := range events {
+		if ev.Name == "gen_ai.choice" {
+			var idx int64
+			var finishReason, content string
+			for _, attr := range ev.Attributes {
+				switch attr.Key {
+				case "index":
+					idx = attr.Value.AsInt64()
+				case "gen_ai.response.finish_reason":
+					finishReason = attr.Value.AsString()
+				case "content":
+					content = attr.Value.AsString()
+				}
+			}
+			if idx == 0 && finishReason == "stop" && content == "First response" {
+				foundChoice0 = true
+			}
+			if idx == 1 && finishReason == "length" && content == "Second response" {
+				foundChoice1 = true
+			}
+		}
+	}
+	if !foundChoice0 {
+		t.Error("Did not find gen_ai.choice event for first choice")
+	}
+	if !foundChoice1 {
+		t.Error("Did not find gen_ai.choice event for second choice")
+	}
+}
+
+func TestOtelMiddleware_ChatCompletion_EmitsToolCallsAttributes(t *testing.T) {
+	toolCallParam := openai.ChatCompletionMessageToolCallParam{
+		ID:   "call_abc123",
+		Type: "function",
+		Function: openai.ChatCompletionMessageToolCallFunctionParam{
+			Name:      "get_weather",
+			Arguments: "{\"location\":\"Paris\"}",
+		},
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := openai.ChatCompletion{
+			ID:    "chatcmpl-789",
+			Model: "gpt-4",
+			Choices: []openai.ChatCompletionChoice{{
+				Index:        0,
+				FinishReason: "tool_calls",
+				Message: openai.ChatCompletionMessage{
+					Role:    "assistant",
+					Content: "",
+					ToolCalls: []openai.ChatCompletionMessageToolCall{{
+						ID:   toolCallParam.ID,
+						Type: toolCallParam.Type,
+						Function: openai.ChatCompletionMessageToolCallFunction{
+							Name:      toolCallParam.Function.Name,
+							Arguments: toolCallParam.Function.Arguments,
+						},
+					}},
+				},
+			}},
+			Usage: openai.CompletionUsage{
+				PromptTokens:     5,
+				CompletionTokens: 7,
+				TotalTokens:      12,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	})
+	env := SetupTest(t, handler, OtelMiddlewareConfig{AddEventDetails: true})
+	client := env.Client
+	spanRecorder := env.SpanRecorder
+
+	// Create a chat completion request
+	ctx := context.Background()
+	params := openai.ChatCompletionNewParams{
+		Model: "gpt-4",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{
+				OfUser: &openai.ChatCompletionUserMessageParam{
+					Content: openai.ChatCompletionUserMessageParamContentUnion{
+						OfString: param.NewOpt("Hi!"),
+					},
+				},
+			},
+		},
+	}
+
+	// Make the request
+	_, err := client.Chat.Completions.New(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to make chat completion request: %v", err)
+	}
+
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("No spans were recorded")
+	}
+
+	span := spans[0]
+	found := false
+	// Build expected JSON using the param type
+	expectedToolCalls := map[string]toolCallData{
+		toolCallParam.ID: {
+			ID:   toolCallParam.ID,
+			Type: string(toolCallParam.Type),
+			Function: toolCallFunctionData{
+				Name:      toolCallParam.Function.Name,
+				Arguments: toolCallParam.Function.Arguments,
+			},
+		},
+	}
+	expectedJSON, _ := json.Marshal(expectedToolCalls)
+
+	for _, ev := range span.Events() {
+		if ev.Name == "gen_ai.choice" {
+			for _, attr := range ev.Attributes {
+				if attr.Key == "tool_calls" && attr.Value.AsString() == string(expectedJSON) {
+					found = true
+				}
+			}
+		}
+	}
+
+	if !found {
+		t.Errorf("Missing or incorrect tool_calls attribute with expected JSON: %s", string(expectedJSON))
+	}
+}
+
+func TestOtelMiddleware_ErrorFromNext(t *testing.T) {
+	errMiddleware := func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+		return nil, fmt.Errorf("simulated error")
+	}
+	env := SetupTest(t, nil, OtelMiddlewareConfig{}, errMiddleware)
+	client := env.Client
+	spanRecorder := env.SpanRecorder
+
+	ctx := context.Background()
+	params := openai.ChatCompletionNewParams{
+		Model: "gpt-4",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{
+				OfUser: &openai.ChatCompletionUserMessageParam{
+					Content: openai.ChatCompletionUserMessageParamContentUnion{
+						OfString: param.NewOpt("Hello"),
+					},
+				},
+			},
+		},
+	}
+	_, err := client.Chat.Completions.New(ctx, params)
+	if err == nil || err.Error() != "simulated error" {
+		t.Fatalf("Expected simulated error, got: %v", err)
+	}
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("No spans were recorded")
+	}
+	span := spans[0]
+	if span.Status().Code != codes.Error {
+		t.Errorf("Expected span status error, got %v", span.Status().Code)
+	}
+	foundErrType := false
+	for _, attr := range span.Attributes() {
+		if attr.Key == semconv.ErrorTypeKey {
+			foundErrType = true
+			if attr.Value.AsString() != "*errors.errorString" {
+				t.Errorf("Expected error type '*errors.errorString', got '%s'", attr.Value.AsString())
+			}
+		}
+	}
+	if !foundErrType {
+		t.Error("Expected error type attribute on span")
+	}
+
+	recorded := false
+	for _, event := range span.Events() {
+		if event.Name == "exception" {
+			recorded = true
+			break
+		}
+	}
+	if !recorded {
+		t.Error("Expected error to be recorded as an exception event on the span")
+	}
+}
+
+func TestOtelMiddleware_Handles4xxResponse(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"error":"bad request"}`))
+	})
+	env := SetupTest(t, handler, OtelMiddlewareConfig{})
+	client := env.Client
+	spanRecorder := env.SpanRecorder
+
+	ctx := context.Background()
+	params := openai.ChatCompletionNewParams{
+		Model: "gpt-4",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{
+				OfUser: &openai.ChatCompletionUserMessageParam{
+					Content: openai.ChatCompletionUserMessageParamContentUnion{
+						OfString: param.NewOpt("Hello"),
+					},
+				},
+			},
+		},
+	}
+	_, err := client.Chat.Completions.New(ctx, params)
+	if err == nil {
+		t.Fatal("Expected error for 400 response, got nil")
+	}
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("No spans were recorded")
+	}
+	span := spans[0]
+	if span.Status().Code != codes.Error {
+		t.Errorf("Expected span status error, got %v", span.Status().Code)
+	}
+	foundErrType := false
+	for _, attr := range span.Attributes() {
+		if attr.Key == semconv.ErrorTypeKey {
+			foundErrType = true
+			if attr.Value.AsString() != "400" {
+				t.Errorf("Expected error type '400', got '%s'", attr.Value.AsString())
+			}
+		}
+	}
+	if !foundErrType {
+		t.Error("Expected error type attribute on span")
+	}
+}
+
+func TestOtelMiddleware_Handles5xxResponse(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"error":"internal error"}`))
+	})
+	env := SetupTest(t, handler, OtelMiddlewareConfig{})
+	client := env.Client
+	spanRecorder := env.SpanRecorder
+
+	ctx := context.Background()
+	params := openai.ChatCompletionNewParams{
+		Model: "gpt-4",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{
+				OfUser: &openai.ChatCompletionUserMessageParam{
+					Content: openai.ChatCompletionUserMessageParamContentUnion{
+						OfString: param.NewOpt("Hello"),
+					},
+				},
+			},
+		},
+	}
+	_, err := client.Chat.Completions.New(ctx, params)
+	if err == nil {
+		t.Fatal("Expected error for 500 response, got nil")
+	}
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("No spans were recorded")
+	}
+	span := spans[0]
+	if span.Status().Code != codes.Error {
+		t.Errorf("Expected span status error, got %v", span.Status().Code)
+	}
+	foundErrType := false
+	for _, attr := range span.Attributes() {
+		if attr.Key == semconv.ErrorTypeKey {
+			foundErrType = true
+			if attr.Value.AsString() != "500" {
+				t.Errorf("Expected error type '500', got '%s'", attr.Value.AsString())
+			}
+		}
+	}
+	if !foundErrType {
+		t.Error("Expected error type attribute on span")
+	}
+}
+
+func TestOtelMiddleware_FineTuningJob_NoGenAIAttributes(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{
+			"id":            "ftjob-123",
+			"object":        "fine_tuning.job",
+			"model":         "gpt-3.5-turbo",
+			"status":        "queued",
+			"created_at":    1234567890,
+			"training_file": "file-abc123",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	})
+	env := SetupTest(t, handler, OtelMiddlewareConfig{})
+	client := env.Client
+	spanRecorder := env.SpanRecorder
+
+	ctx := context.Background()
+	params := openai.FineTuningJobNewParams{
+		Model:        "gpt-3.5-turbo",
+		TrainingFile: "file-abc123",
+	}
+
+	_, err := client.FineTuning.Jobs.New(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to create finetuning job: %v", err)
+	}
+
+	spans := spanRecorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("No spans were recorded")
+	}
+
+	span := spans[0]
+
+	// The span name should be the fallback (not a GenAI operation)
+	expectedSpanName := "POST /fine_tuning/jobs"
+	if span.Name() != expectedSpanName {
+		t.Errorf("Expected span name '%s', got '%s'", expectedSpanName, span.Name())
+	}
+
+	attrs := span.Attributes()
+	// Should not have any gen_ai.* attributes
+	for _, attr := range attrs {
+		if strings.HasPrefix(string(attr.Key), "gen_ai.") {
+			t.Errorf("Unexpected GenAI attribute on span: %s", attr.Key)
+		}
+	}
+
+	// Should have HTTP and server attributes
+	hasMethod := false
+	hasURL := false
+	hasServer := false
+	for _, attr := range attrs {
+		if attr.Key == semconv.HTTPRequestMethodKey {
+			hasMethod = true
+		}
+		if attr.Key == semconv.URLFullKey {
+			hasURL = true
+		}
+		if attr.Key == semconv.ServerAddressKey {
+			hasServer = true
+		}
+	}
+	if !hasMethod {
+		t.Error("Missing HTTP method attribute on span")
+	}
+	if !hasURL {
+		t.Error("Missing URL attribute on span")
+	}
+	if !hasServer {
+		t.Error("Missing server address attribute on span")
+	}
+}

--- a/internal/otel/trace/sampler.go
+++ b/internal/otel/trace/sampler.go
@@ -9,7 +9,7 @@ import (
 	rsemconv "github.com/dynoinc/ratchet/internal/otel/semconv"
 )
 
-// forceBasedSampler is a custom OpenTelemetry trace sampler that samples 100% of traces with force_trace=true attribute
+// forceBasedSampler samples 100% of traces with force_trace=true attribute
 // and uses default sampling rate for all other traces
 type forceBasedSampler struct {
 	defaultSampler sdkTrace.Sampler


### PR DESCRIPTION
Implement a middleware for the OpenAI client that will trace chat and embedding requests and responses following the OTEL semantic conventions.

Also, wrap the MCP tool call with a span -- also following the OTEL spec. Note that the MCP tool call is wrapped inside a helper function because middleware isn't supported in the mcp-go Client, and because the MCP server could be in another process, we need to instrument on the client side.