### PR TITLE
ci: bump GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,17 +18,17 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@v4
 
       - name: Run tests
         run: just test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       COMMIT_HASH: ${{ steps.commit_and_push.outputs.COMMIT_HASH }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -58,10 +58,10 @@ jobs:
           echo "VERSION=v$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry (early)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build Docker Image
         if: steps.check_commits.outputs.NEW_COMMITS == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64
@@ -83,7 +83,7 @@ jobs:
       - name: Scan Docker Image with Trivy
         id: trivy_scan
         if: steps.check_commits.outputs.NEW_COMMITS == 'true'
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: ratchet:latest
           format: "sarif"
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload SARIF Report
         if: steps.check_commits.outputs.NEW_COMMITS == 'true'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
 
@@ -130,12 +130,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.bump_scan_push.outputs.COMMIT_HASH }}
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.bump_scan_push.outputs.VERSION }}
           name: Release ${{ needs.bump_scan_push.outputs.VERSION }}


### PR DESCRIPTION
## Summary
- Bump workflow action versions where newer tags are available.
- Move core GitHub Actions to Node 24-capable major versions where applicable.

## Verification
- Existing GitHub Actions workflows will validate this PR.